### PR TITLE
Fix code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/src/cluster_tasks/debug_task_sync.py
+++ b/src/cluster_tasks/debug_task_sync.py
@@ -50,7 +50,7 @@ def main():
                 result = node_tasks.vm_config_network_set(
                     node, destination_vm_id, config=setconfig
                 )
-                logger.info(result, setconfig)
+                logger.info(f"VM configuration network set result: {result}")
                 logger.info(
                     api.nodes(node)
                     .qemu(destination_vm_id)


### PR DESCRIPTION
Fixes [https://github.com/lexxai/proxmox_cluster_tasks/security/code-scanning/3](https://github.com/lexxai/proxmox_cluster_tasks/security/code-scanning/3)

To fix the problem, we should avoid logging sensitive information in clear text. Instead of logging the entire `setconfig` dictionary, we can log a message indicating the action being performed without including the sensitive details. This way, we maintain the functionality of logging important events without exposing sensitive data.

- Identify the lines where sensitive data is being logged.
- Replace the logging statements with more generic messages that do not include sensitive information.
- Ensure that the changes do not affect the existing functionality of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
