### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/src/cluster_tasks/debug_task_sync.py
+++ b/src/cluster_tasks/debug_task_sync.py
@@ -10,6 +10,10 @@ from loader_scene import ScenarioFactory
 
 logger = logging.getLogger(f"CT.{__name__}")
 
+def sanitize_config(config):
+    sensitive_keys = ["API.TOKEN_SECRET", "API.TOKEN_ID"]
+    sanitized_config = {k: (v if k not in sensitive_keys else "****") for k, v in config.items()}
+    return sanitized_config
 
 def main():
     config_file = Path(__file__).parent / "scenarios_configs.yaml"
@@ -24,7 +28,8 @@ def main():
             node_tasks = ProxmoxTasksSync(api=api)
             for v in scenarios_config.get("Scenarios").values():
                 config = v.get("config")
-                logger.debug(f"Config: {config}")
+                sanitized_config = sanitize_config(config)
+                logger.debug(f"Config: {sanitized_config}")
                 node = config.get("node")
                 source_vm_id = config.get("source_vm_id")
                 destination_vm_id = config.get("destination_vm_id")


### PR DESCRIPTION
Fixes [https://github.com/lexxai/proxmox_cluster_tasks/security/code-scanning/1](https://github.com/lexxai/proxmox_cluster_tasks/security/code-scanning/1)

To fix the problem, we need to ensure that sensitive information is not logged in clear text. The best way to do this is to sanitize the `config` object before logging it, removing or masking any sensitive information. This can be done by creating a function that filters out sensitive keys from the `config` object before logging it.

We will modify the `main` function in `src/cluster_tasks/debug_task_sync.py` to use this sanitization function before logging the `config` object. Additionally, we will add the sanitization function to the same file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
